### PR TITLE
Make audience URI matching less brittle

### DIFF
--- a/lib/response-validation.js
+++ b/lib/response-validation.js
@@ -280,14 +280,11 @@ ResponseValidator.prototype.validateConditions = function(assertion) {
 
 	const audienceRestriction = select("saml:AudienceRestriction", conditions)[0];
 	if (audienceRestriction) {
-		let matchesAudience = false;
 		const resolvedEntityID = urlParse(this.sp.entityID).href;
 		const audiences = select("saml:Audience", audienceRestriction);
-		audiences.forEach(audience => {
+		const matchesAudience = audiences.some(audience => {
 			const resolvedAudienceURI = urlParse(audience.textContent || "").href;
-			if (resolvedAudienceURI == resolvedEntityID) {
-				matchesAudience = true;
-			}
+			return resolvedAudienceURI == resolvedEntityID;
 		});
 		if (!matchesAudience) {
 			this.addError("Conditions.AudienceRestriction.Audience does not match the service provider");

--- a/lib/response-validation.js
+++ b/lib/response-validation.js
@@ -7,6 +7,7 @@ const credentials      = require("./util/credentials");
 const namespaces       = require("./namespaces");
 const protocolBindings = require("./protocol-bindings");
 const moment 		   = require("moment");
+const urlParse = require("url").parse;
 
 const select = xpath.useNamespaces(namespaces);
 
@@ -280,9 +281,11 @@ ResponseValidator.prototype.validateConditions = function(assertion) {
 	const audienceRestriction = select("saml:AudienceRestriction", conditions)[0];
 	if (audienceRestriction) {
 		let matchesAudience = false;
+		const resolvedEntityID = urlParse(this.sp.entityID).href;
 		const audiences = select("saml:Audience", audienceRestriction);
 		audiences.forEach(audience => {
-			if (audience.textContent == this.sp.entityID) {
+			const resolvedAudienceURI = urlParse(audience.textContent || "").href;
+			if (resolvedAudienceURI == resolvedEntityID) {
 				matchesAudience = true;
 			}
 		});

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "@socialtables/saml-protocol",
   "version": "0.3.3",
   "description": "A SAML protocol implementation for SPs and IDPs without opinionated framework bindings",
-  "author": {
-    "name": "Social Tables",
-    "url": "https://www.socialtables.com"
-  },
+  "author": "Social Tables (https://www.socialtables.com)",
   "main": "lib/index.js",
   "keywords": [
     "saml",
@@ -16,7 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/socialtables/saml-protocol.git"
   },
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=4.0.0"
   },
@@ -42,5 +39,12 @@
     "eslint-plugin-mocha": "^4.5.1",
     "eslint-plugin-node": "^2.0.0",
     "mocha": "^2.2.5"
+  },
+  "bugs": {
+    "url": "https://github.com/socialtables/saml-protocol/issues"
+  },
+  "homepage": "https://github.com/socialtables/saml-protocol#readme",
+  "directories": {
+    "test": "test"
   }
 }

--- a/test/fixtures/entities.js
+++ b/test/fixtures/entities.js
@@ -50,6 +50,24 @@ module.exports = {
 		requireSignedRequests: false
 	},
 
+	simpleIDPWithCredentialsAndURIEntityID: {
+		entityID: "https://entityuri-idp.test.com",
+		credentials: [
+			credentialFixtures.idp1
+		],
+		endpoints: {
+			login: "https://entityuri-idp.test.com/saml/login",
+			logout: {
+				post: "https://entityuri-idp.test.com/saml/logout"
+			}
+		},
+		nameIDFormats: [
+			"urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+		],
+		signAllResponses: true,
+		requireSignedRequests: false
+	},
+
 	// SPs
 	simpleSP: {
 		entityID: "sp.test.com",
@@ -68,6 +86,23 @@ module.exports = {
 		],
 		endpoints: {
 			assert: "sp.test.com/assert"
+		},
+		signAllRequests: true,
+		requireSignedResponses: true,
+		extendedRequirements: {
+			InResponseTo: true,
+			NotOnOrAfter: true,
+			Recipient: true
+		}
+	},
+	simpleSPWithCredentialsAndURIEntityID: {
+		entityID: "https://entityuri-idp.test.com",
+		credentials: [
+			credentialFixtures.sp1,
+			credentialFixtures.sp2
+		],
+		endpoints: {
+			assert: "https://entityuri-idp.test.com/assert"
 		},
 		signAllRequests: true,
 		requireSignedResponses: true,

--- a/test/sp-security-checklist.js
+++ b/test/sp-security-checklist.js
@@ -29,8 +29,8 @@ describe("Service Provider security checklist", function() {
 	const responseConstruction = require("../lib/response-construction");
 	const responseHandling = require("../lib/response-handling");
 
-	const sp = entityFixtures.simpleSPWithCredentials;
-	const idp = entityFixtures.simpleIDPWithCredentials;
+	let sp = entityFixtures.simpleSPWithCredentials;
+	let idp = entityFixtures.simpleIDPWithCredentials;
 	const idpWithLatency = entityFixtures.simpleIDPWithLatency;
 
 	describe("Response:Assertion:Subject:SubjectConfirmation:SubjectConfirmationData element (With Latency)", function() {
@@ -482,6 +482,35 @@ describe("Service Provider security checklist", function() {
 						err.errors.length.should.equal(1);
 						err.errors.join("").should.have.string("Audience does not match");
 					});
+			});
+
+			it("should be ok if the entityID is just a string", function () {
+				return buildValidResponse()
+					.then(parse)
+					.then(doc => {
+						const audience = select("//saml:Conditions/saml:AudienceRestriction/saml:Audience", doc)[0];
+						audience.textContent = sp.entityID;
+						return doc;
+					})
+					.then(consume).should.eventually.be.fulfilled;
+			});
+
+			let _sp, _idp;
+			before(function () {
+				_sp = sp;
+				_idp = idp;
+				sp = entityFixtures.simpleSPWithCredentialsAndURIEntityID;
+				idp = entityFixtures.simpleIDPWithCredentialsAndURIEntityID;
+			});
+			after(function () {
+				sp = _sp;
+				idp = _idp;
+			});
+
+			it("should be ok if the entityIDs are different strings that resolve to the same URL", function () {
+				return buildValidResponse()
+					.then(parse)
+					.then(consume).should.eventually.be.fulfilled;
 			});
 		});
 		


### PR DESCRIPTION
Currently, AudienceRestriction matching uses simple string comparison. As a result, https://somehostname.com and https://somehostname.com/ fail to match, even though they resolve to the same URL.

This is unnecessarily brittle.

With these changes, if the entityID is a string that does **not** resolve to a URL (for example, "abc123", which is perfectly legal), nothing changes. However, if the entityID is a string that **does** resolve to a URL (for example, https://somehostname.com/), then any string that resolves to the same URL will be a valid match for the AudienceRestriction condition.

This addresses a hard-to-diagnose implementation bug, where human error configuring the IdP can lead to adding or omitting the trailing slash from a root URL.