### PR TITLE
use >= instead of == for authn request class

### DIFF
--- a/lib/request-construction.js
+++ b/lib/request-construction.js
@@ -70,7 +70,7 @@ function createAuthnRequest(sp, idp, model, destinationURL) {
 					"@AllowCreate": true
 				}} : null),
 				{ "samlp:RequestedAuthnContext": {
-					"@Comparison": "exact",
+					"@Comparison": "minimum",
 					"saml:AuthnContextClassRef": protocol.AUTHNCONTEXT.PASSWORDPROTECTEDTRANSPORT
 				}}
 			].filter(exists => exists)


### PR DESCRIPTION
An IDP might have multiple authentication mechanisms. For example for ADFS: https://msdn.microsoft.com/en-us/library/hh599318.aspx , where password protected is seen as one of the weakest. An IDP might choose to only authenticate using a stronger mechanism, but the current authentication request send by this library wants an exact match for 'password protected transport'. By changing this to minimal, you can also support the stronger ones.