### PR TITLE
fixed the XML Attribute for the instance of authentication

### DIFF
--- a/lib/response-construction.js
+++ b/lib/response-construction.js
@@ -225,7 +225,7 @@ function constructAssertion(sp, idp, inResponseTo, nameID, attributes, issueInst
 				}
 			}},
 			{ "saml:AuthnStatement": {
-				"@AuthInstant": now.toISOString(),
+				"@AuthnInstant": now.toISOString(),
 				"@SessionNotOnOrAfter": later.toISOString(),
 				"@SessionIndex": "0",
 				"saml:AuthnContex": {


### PR DESCRIPTION
IDP authentication time went from AuthInstant => AuthnInstant 

This is already seen in onelogin-saml-response.xml