### PR TITLE
[STESV-1054]: Add support for multiple signing and encryption credentials

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -125,7 +125,9 @@ function createIDPSSODescriptorJSON(idp) {
 	// build signing key descriptor
 	const signingCredentials = credentials.getCredentialsFromEntity(idp, "signing");
 	if (signingCredentials.length > 0) {
-		descriptorBody.push(createSigningKeyDescriptorJSON(signingCredentials[0].certificate));
+		signingCredentials.forEach(credential => {
+			descriptorBody.push(createSigningKeyDescriptorJSON(credential.certificate));
+		});
 	}
 
 	// right now the IDP does not support encryption,
@@ -213,10 +215,14 @@ function createSPSSODescriptorJSON(sp) {
 	const encryptionCredentials = credentials.getCredentialsFromEntity(sp, "encryption");
 
 	if (signingCredentials.length > 0) {
-		descriptorBody.push(createSigningKeyDescriptorJSON(signingCredentials[0].certificate));
+		signingCredentials.forEach(credential => {
+			descriptorBody.push(createSigningKeyDescriptorJSON(credential.certificate));
+		});
 	}
 	if (encryptionCredentials.length > 0) {
-		descriptorBody.push(createEncryptionKeyDescriptorJSON(encryptionCredentials[0].certificate));
+		encryptionCredentials.forEach(credential => {
+			descriptorBody.push(createEncryptionKeyDescriptorJSON(credential.certificate));
+		});
 	}
 
 	// add supported NameIDFormats if specified


### PR DESCRIPTION
This lets us publish the old and new cert side by side in the metadata, which should cause IDPs to add both.